### PR TITLE
Adapter options aren't required to be string or symbol

### DIFF
--- a/templates/default/lita_config.rb.erb
+++ b/templates/default/lita_config.rb.erb
@@ -6,7 +6,7 @@ Lita.configure do |config|
   config.robot.admins = ["<%= node['lita']['admin'].join('","') %>"]
   config.robot.adapter = <%= string_or_symbol(node['lita']['adapter']) %>
 <% node['lita']['adapter_config'].each do |k,v| -%>
-  config.adapter.<%= k %> = <%= string_or_symbol(v) %>
+  config.adapter.<%= k %> = <%= v %>
 <% end -%>
   config.redis.host = "<%= node['lita']['redis_host'] %>"
   config.redis.port = <%= node['lita']['redis_port'] %>


### PR DESCRIPTION
```
config.adapter  Lita::Config    Options for the chosen adapter. See the adapter's documentation.    N/A
```

For example https://github.com/josacar/lita-campfire requires 'config.adapter.rooms' to be an array.
