### PR TITLE
Doesn't need sudo here. Use su (useful for rbenv). Don't hide errors

### DIFF
--- a/templates/default/lita.erb
+++ b/templates/default/lita.erb
@@ -28,7 +28,7 @@ pid() {
 }
 
 start() {
-  su - $DAEMON_USER bash -c "export HOME=$HOME_DIR; cd $HOME_DIR; $CMD_FILE $CMD_OPTS"
+  su - $DAEMON_USER bash -c "export HOME=$HOME_DIR; cd $HOME_DIR; $CMD_FILE $CMD_OPTS >><%= node["lita"]["log_dir"] %>/daemon.log 2>&1"
   echo "* lita is started"
 }
 


### PR DESCRIPTION
Switch from 'sudo' to 'su -'
It loads environment and if there's rbenv installed for app user it'll pick it up.
Also stop hiding errors. It's impossible to debug if start script sends all the output to `/dev/null`
