### PR TITLE
Switch Redis config to hash-style access

### DIFF
--- a/templates/default/lita_config.rb.erb
+++ b/templates/default/lita_config.rb.erb
@@ -18,8 +18,8 @@ Lita.configure do |config|
   config.adapter.<%= k %> = <%= typecast(v) %>
 <% end -%>
 <% end -%>
-  config.redis.host = <%= typecast(node['lita']['redis_host']) %>
-  config.redis.port = <%= typecast(node['lita']['redis_port']) %>
+  config.redis[:host] = <%= typecast(node['lita']['redis_host']) %>
+  config.redis[:port] = <%= typecast(node['lita']['redis_port']) %>
   config.http.host = <%= typecast(node['lita']['http_host']) %>
   config.http.port = <%= typecast(node['lita']['http_port']) %>
   config.http.min_threads = <%= typecast(node['lita']['http_min_threads']) %>


### PR DESCRIPTION
Fixes https://github.com/litaio/chef-lita/issues/12, by switching the Redis config in the template from struct to hash style.  (Which was introduced in [Lita 4.0](http://docs.lita.io/releases/4/#upgrading-for-users))