### PR TITLE
Allow overriding of Gemfile and init templates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,8 @@ default["lita"]["mention_name"] = node["lita"]["name"]
 # override with custom template for more complex configurations)
 default["lita"]["config_cookbook"] = "lita"
 default["lita"]["config_template"] = "lita_config.rb.erb"
+default["lita"]["gemfile_template"] = "Gemfile.erb"
+default["lita"]["init_template"] = "lita.erb"
 
 # The locale code for the language to use.
 default["lita"]["locale"] = :en

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,8 @@ end
 end
 
 template "#{node["lita"]["install_dir"]}/Gemfile" do
+  cookbook node["lita"]["config_cookbook"]
+  source   node["lita"]["gemfile_template"]
   notifies :delete, "file[Gemfile.lock]", :immediately
   notifies :run, "execute[chown-openup]", :immediately
   notifies :run, "execute[bundle-install-lita]", :immediately
@@ -109,6 +111,8 @@ template "#{node["lita"]["install_dir"]}/lita_config.rb" do
 end
 
 template "/etc/init.d/lita" do
+  cookbook node["lita"]["config_cookbook"]
+  source node["lita"]["init_template"]
   mode "0755"
   notifies :restart, "service[lita]"
 end


### PR DESCRIPTION
It's useful to be able to override these files in a wrapper cookbook for customization in addition to `lita_config.erb`