### PR TITLE
add Rake tasks for style checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
     - metadata.rb
-    - vendor/**
+    - vendor/**/*
 
 AlignParameters:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,20 @@
+require 'rubocop/rake_task'
+require 'foodcritic'
+
+namespace :style do
+  desc 'Run rubocop linting'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.options = ['--lint']
+    task.fail_on_error = true
+  end
+
+  desc 'Run foodcritic linting'
+  FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
+    t.options = {
+      fail_tags: ['any'],
+    }
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:rubocop', 'style:foodcritic']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -105,7 +105,7 @@ template "#{node["lita"]["install_dir"]}/lita_config.rb" do
   cookbook node["lita"]["config_cookbook"]
   source node["lita"]["config_template"]
   notifies :restart, "service[lita]"
-  helpers (LitaHelpers)
+  helpers(LitaHelpers)
 end
 
 template "/etc/init.d/lita" do


### PR DESCRIPTION
* add rake tasks for running rubocop + foodcritic
* fix rubocop warning for the helpers attribute
* fix rubocop.yml warning for excluding the vendor directory
 
 `Warning: Deprecated pattern style '~/chef-lita/vendor/**' in ~/chef-lita/.rubocop.yml. Change to '~/chef-lita/vendor/**/*'`