### PR TITLE
clean up, allow passing env to runit, make it work with rvm

### DIFF
--- a/attributes/init.rb
+++ b/attributes/init.rb
@@ -1,2 +1,9 @@
 default['lita']['runit']['finish'] = false
+default['lita']['runit']['env'] = {
+  'HOME' => node['lita']['install_dir'],
+  'PATH' => [node['languages']['ruby']['bin_dir'],
+             node['languages']['ruby']['gem_bin'],
+             node['languages']['ruby']['ruby_dir']
+             ].join(':')
+}
 default['lita']['init_style'] = 'runit'

--- a/recipes/runit_service.rb
+++ b/recipes/runit_service.rb
@@ -23,5 +23,7 @@ return unless node['lita']['init_style'] == 'runit'
 include_recipe 'runit'
 
 runit_service 'lita' do
+  cookbook node["lita"]["config_cookbook"]
   finish node['lita']['runit']['finish']
+  env node['lita']['runit']['env']
 end

--- a/templates/default/sv-lita-run.erb
+++ b/templates/default/sv-lita-run.erb
@@ -1,12 +1,8 @@
 #!/bin/sh
 exec 2>&1
 
-DAEMON_USER=<%= node["lita"]["daemon_user"] %>
-HOME_DIR=<%= node["lita"]["install_dir"] %>
-CMD_FILE=<%= node["lita"]["install_dir"] %>/bin/lita
-PID_FILE=<%= node["lita"]["run_dir"] %>/lita.pid
-CMD_OPTS="--pid-file $PID_FILE"
-export HOME=$HOME_DIR
-cd $HOME_DIR
+DAEMON_USER=<%= node['lita']['daemon_user'] %>
+CMD_FILE=<%= node['lita']['install_dir'] %>/bin/lita
+cd <%= node['lita']['install_dir'] %>
 
-exec /usr/bin/env chpst -u $DAEMON_USER $CMD_FILE $CMD_OPTS
+exec /usr/bin/env chpst -e <%= node['runit']['sv_dir'] %>/lita/env/ -u $DAEMON_USER $CMD_FILE


### PR DESCRIPTION
1. We actually do not need pidfile when using runit
2. Exporting in sv-run file probably not the best idea, so I've made it using runit's env.
3. I've faced a problem with using ruby, that is installed via rvm. Now runit should use PATH from ohai attributes. 

It worked for me, but I have not tested with ruby from packages.