### PR TITLE
Desktophero gem source

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,12 @@ suites:
       - recipe[lita::default]
     attributes:
       lita:
+        gem_primary_source: 'https://rubygems.org'
+        name: fakebot
+        version: '4.6'
+        log_level: :info
+        daemon_user: vagrant
+        daemon_group: vagrant
         admin:
           - User1
           - User2

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Key | Type | Description | Default
 `plugins` | Array of Strings and/or Hashes  | List of plugins to install and, optionally, Gemfile line options | empty
 `plugin_config` | Hash of Hashes  | Hash of plugin specific configuration | empty
 `gems` | Array of Strings and/or Hashes  | List of gems to install and, optionally, Gemfile line options | empty
+`gem_primary_source` | String | Source URL for Gemfile `source` | `https://rubygems.org`
 `packages` | Array of Strings | List of system packages to install | SSL related stuff
 `http_host` | String  | IP address to bind http server | 0.0.0.0
 `http_port` | Numeric  | Port to bind http server | 8080

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default["lita"]["config_cookbook"] = "lita"
 default["lita"]["config_template"] = "lita_config.rb.erb"
 default["lita"]["gemfile_template"] = "Gemfile.erb"
 default["lita"]["init_template"] = "lita.erb"
+default['lita']['gem_primary_source'] = 'https://rubygems.org'
 
 # The locale code for the language to use.
 default["lita"]["locale"] = :en

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -70,14 +70,4 @@ describe 'lita::default' do
   it 'executes the recurseive chown of bin and vendor install dir' do
     expect(chef_run).not_to run_execute('chown-bundle')
   end
-
-  it 'installs the lita init.d template' do
-    expect(chef_run).to create_template('/etc/init.d/lita')
-  end
-
-  it 'enabled and starts the lita service' do
-    expect(chef_run).to enable_service('lita')
-    expect(chef_run).to start_service('lita')
-  end
-
 end

--- a/spec/init_service_spec.rb
+++ b/spec/init_service_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'lita::init_service' do
+
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.automatic['platform']         = 'ubuntu'
+      node.automatic['platform_version'] = '12.04'
+      node.automatic['platform_family']  = 'debian'
+      node.automatic['lsb']['codename']  = 'precise'
+      node.automatic['memory']['total']  = 2048
+      node.set['lita']['packages']   = ['openssl']
+      node.set['lita']['init_style'] = 'init'
+    end.converge(described_recipe)
+  end
+
+  it 'installs the lita init.d template' do
+    expect(chef_run).to create_template('/etc/init.d/lita')
+  end
+
+  it 'enabled and starts the lita service' do
+    expect(chef_run).to enable_service('lita')
+    expect(chef_run).to start_service('lita')
+  end
+
+end

--- a/templates/default/Gemfile.erb
+++ b/templates/default/Gemfile.erb
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "<% node['lita']['gem_primary_source'] %>"
 
 gem "lita"<% if node['lita']['version'] -%>, "<%= node['lita']['version_constraint'] -%> <%= node['lita']['version'] %>"<% end -%>
 


### PR DESCRIPTION
Modified the `Gemfile.erb` template to allow a node attribute to drive Gemfile source

There were also some ChefSpec that was failing prior to my changes due to some resources moving to another recipe. I couldn't leave that be.

Only updated README - left CHANGELOG and metadata alone.

Finally, I didn't see any specific rules for contributing back. Fingers crossed this a-okay.

Thanks!


```
Finished in 4.35 seconds (files took 1.48 seconds to load)
19 examples, 0 failures


ChefSpec Coverage report generated...

  Total Resources:   14
  Touched Resources: 11
  Touch Coverage:    78.57%

Untouched Resources:

  execute[chown-openup]              lita/recipes/install.rb:60
  execute[chown-cleanup]             lita/recipes/install.rb:87
  runit_service[lita]                lita/recipes/runit_service.rb:25

Running RuboCop...
Inspecting 19 files
...................

19 files inspected, no offenses detected
```