### PR TITLE
Some Centos Support and a Typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Berksfile.lock
 .ruby-version
 .ruby-gemset
 .bundle/
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Installs and configures the [lita](https://www.lita.io/) chatbot.
  * 12.04 (precise)
  * 14.04 (trusty)
 
+* CentOS
+ * 7 (Installing Ruby & Redis Not Tested)
+
 It will likely work on other Ubuntu versions, however the automatic methods of installing ruby and redis will have issues.
 
 ## Tunable Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,12 +96,24 @@ default["lita"]["gems"] = []
 default["lita"]["plugin_config"] = {}
 
 # helpful for adding native libs needed by adapters / handlers
-default["lita"]["packages"] = %w(
-  openssl
-  libssl-dev
-  ca-certificates
-  libcurl4-gnutls-dev
-)
+case node['platform_family']
+  when 'debian'
+    default["lita"]["packages"] = %w(
+      openssl
+      libssl-dev
+      ca-certificates
+      libcurl4-gnutls-dev
+    )
+  when 'rhel'
+    default["lita"]["packages"] = %w(
+      openssl
+      openssl-devel
+      ca-certificates
+      libcurl-devel
+      libpcap-devel
+    )
+end
+
 
 # Set options for redis connection
 default["lita"]["redis_host"] = "127.0.0.1"

--- a/templates/default/Gemfile.erb
+++ b/templates/default/Gemfile.erb
@@ -1,4 +1,4 @@
-source "<% node['lita']['gem_primary_source'] %>"
+source "<%= node['lita']['gem_primary_source'] %>"
 
 gem "lita"<% if node['lita']['version'] -%>, "<%= node['lita']['version_constraint'] -%> <%= node['lita']['version'] %>"<% end -%>
 


### PR DESCRIPTION
Added a case for the pre-req packages to get this to work on Centos 7.

I also found a missing = sign in the erb for 'source' which was causing it to pop out with an empty value.