### PR TITLE
service as attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,25 +97,24 @@ default["lita"]["plugin_config"] = {}
 
 # helpful for adding native libs needed by adapters / handlers
 case node['platform_family']
-  when 'debian'
-    default["lita"]["packages"] = %w(
-      openssl
-      libssl-dev
-      ca-certificates
-      libcurl4-gnutls-dev
-      git
-    )
-  when 'rhel'
-    default["lita"]["packages"] = %w(
-      openssl
-      openssl-devel
-      ca-certificates
-      libcurl-devel
-      libpcap-devel
-      git
-    )
+when 'debian'
+  default["lita"]["packages"] = %w(
+    openssl
+    libssl-dev
+    ca-certificates
+    libcurl4-gnutls-dev
+    git
+  )
+when 'rhel'
+  default["lita"]["packages"] = %w(
+    openssl
+    openssl-devel
+    ca-certificates
+    libcurl-devel
+    libpcap-devel
+    git
+  )
 end
-
 
 # Set options for redis connection
 default["lita"]["redis_host"] = "127.0.0.1"
@@ -140,6 +139,10 @@ when 'debian'
 when 'rhel'
   default["lita"]["daemon_group"] = "nobody"
 end
+
+# default service actions
+# set to symbol of :nothing if not needed
+default['lita']['service'] = [:enable, :start]
 
 # dependency install type:
 #

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# build service values
+
 case node['lita']['init_style']
 when 'init'
   template "/etc/init.d/lita" do
@@ -29,7 +31,7 @@ when 'init'
   end
   service "lita" do
     supports :status => true, :restart => true
-    action [:enable, :start]
+    action node['lita']['service']
   end
 else
   include_recipe 'runit'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'lita::default' do
 
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['platform']         = 'ubuntu'
       node.automatic['platform_version'] = '12.04'
       node.automatic['platform_family']  = 'debian'
@@ -11,6 +11,11 @@ describe 'lita::default' do
       node.automatic['memory']['total']  = 2048
       node.set['lita']['packages']   = ['openssl']
     end.converge(described_recipe)
+  end
+
+  let(:group_name) do
+    return 'nogroup' if chef_run.node.automatic['platform_family'] == 'debian'
+    return 'nobody'
   end
 
   it 'includes the default recipe from the apt cookbook' do
@@ -40,14 +45,14 @@ describe 'lita::default' do
   it 'creates the lita log directory' do
     expect(chef_run).to create_directory('/opt/lita/logs').with(
       user:  'nobody',
-      group: 'nobody'
+      group: group_name
     )
   end
 
   it 'creates the lita run directory' do
     expect(chef_run).to create_directory('/opt/lita/run').with(
       user:  'nobody',
-      group: 'nobody'
+      group: group_name
     )
   end
 

--- a/spec/init_service_spec.rb
+++ b/spec/init_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'lita::init_service' do
 
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['platform']         = 'ubuntu'
       node.automatic['platform_version'] = '12.04'
       node.automatic['platform_family']  = 'debian'

--- a/spec/init_service_spec.rb
+++ b/spec/init_service_spec.rb
@@ -11,6 +11,7 @@ describe 'lita::init_service' do
       node.automatic['memory']['total']  = 2048
       node.set['lita']['packages']   = ['openssl']
       node.set['lita']['init_style'] = 'init'
+      node.set['lita']['service'] = [:enable, :start]
     end.converge(described_recipe)
   end
 
@@ -18,9 +19,70 @@ describe 'lita::init_service' do
     expect(chef_run).to create_template('/etc/init.d/lita')
   end
 
-  it 'enabled and starts the lita service' do
-    expect(chef_run).to enable_service('lita')
-    expect(chef_run).to start_service('lita')
+  context 'service options are true' do
+    it 'enabled and starts the lita service' do
+      expect(chef_run).to enable_service('lita')
+      expect(chef_run).to start_service('lita')
+    end
   end
 
+  context 'service options are :enable only' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.automatic['platform']         = 'ubuntu'
+        node.automatic['platform_version'] = '12.04'
+        node.automatic['platform_family']  = 'debian'
+        node.automatic['lsb']['codename']  = 'precise'
+        node.automatic['memory']['total']  = 2048
+        node.set['lita']['packages']   = ['openssl']
+        node.set['lita']['init_style'] = 'init'
+        node.set['lita']['service'] = [:enable]
+      end.converge(described_recipe)
+    end
+
+    it 'enabled and starts the lita service' do
+      expect(chef_run).to enable_service('lita')
+      expect(chef_run).to_not start_service('lita')
+    end
+  end
+
+  context 'service options are :start only' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.automatic['platform']         = 'ubuntu'
+        node.automatic['platform_version'] = '12.04'
+        node.automatic['platform_family']  = 'debian'
+        node.automatic['lsb']['codename']  = 'precise'
+        node.automatic['memory']['total']  = 2048
+        node.set['lita']['packages']   = ['openssl']
+        node.set['lita']['init_style'] = 'init'
+        node.set['lita']['service'] = [:start]
+      end.converge(described_recipe)
+    end
+
+    it 'enabled and starts the lita service' do
+      expect(chef_run).to_not enable_service('lita')
+      expect(chef_run).to start_service('lita')
+    end
+  end
+
+  context 'service options are :nothing only' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.automatic['platform']         = 'ubuntu'
+        node.automatic['platform_version'] = '12.04'
+        node.automatic['platform_family']  = 'debian'
+        node.automatic['lsb']['codename']  = 'precise'
+        node.automatic['memory']['total']  = 2048
+        node.set['lita']['packages']   = ['openssl']
+        node.set['lita']['init_style'] = 'init'
+        node.set['lita']['service'] = [:nothing]
+      end.converge(described_recipe)
+    end
+
+    it 'enabled and starts the lita service' do
+      expect(chef_run).to_not enable_service('lita')
+      expect(chef_run).to_not start_service('lita')
+    end
+  end
 end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'lita::redis' do
 
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['platform']         = 'ubuntu'
       node.automatic['platform_version'] = '12.04'
       node.automatic['platform_family']  = 'debian'

--- a/spec/ruby_spec.rb
+++ b/spec/ruby_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'lita::ruby' do
 
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['platform']         = 'ubuntu'
       node.automatic['platform_version'] = '12.04'
       node.automatic['platform_family']  = 'debian'
@@ -20,4 +20,7 @@ describe 'lita::ruby' do
     expect(chef_run).to install_package('ruby2.1-dev')
   end
 
+  it 'installs the Gem for bundler' do
+    expect(chef_run).to install_gem_package('bundler')
+  end
 end


### PR DESCRIPTION
#### Use Case:

I'd like to have the service options for `:start` and `:enable` as an attribute so I can modify them within my wrapper cookbook. The reason for that is I can then control credentials/secrets via ChefVault on a bot server rebuild (I rebuild in our private cloud at least once a month to validate it can be done - self-imposed disaster recovery).

This PR enables this. The default values remain unchanged as to remove the option affecting others who don't care ( :smiley: )

I define the attribute as an array of symbols and then remove the symbol notation in the `action` property of the service resource.
#### Extra Stuff:
- attributes/default.rb - small indent cleanup of a `case` statement
- Spec tests now lean on SoloRunner 
#### Spec Tests
- default_spec: added a `let` statement to override `group` value for platform specific options. This would also allow a company/team/person to update local tests based on their standards that might be different than an OS standard (... could happen). When I ran tests locally, they were failing ... Had to fix them first before adding something new.
- added `bundler` spec to `ruby`
- added `service` spec tests to account for variations to the acceptable service offerings confined to `:enable` and `:start` (note: the extra converges did add almost a second for rspec on my machine :disappointed: ) < -- I'm down for a more preferred approach but this did the needful
